### PR TITLE
Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,121 @@ Install
 
 
 
-What?
+API
 -----
 
+### `header` module
+
+```js
+import * as header from 'secure-container/lib/header'
+// OR
+const header = require('secure-container/lib/header')
+```
+
+#### `header.create(data)`
+
+Create a header object.
+
+- `data` (Object)
+  - `appName` (String) Name of your app
+  - `appVersion` (String) Version of your app
+
+Returns an Object.
+
+#### `header.serialize(headerObj)`
+
+Serialize a header object. `headerObj` is a header object made with `create()`. Returns a Buffer.
+
+### `metadata` module
+
+```js
+import * as metadata from 'secure-container/lib/metadata'
+// OR
+const metadata = require('secure-container/lib/metadata')
+```
+
+#### `metadata.create()`
+
+Create a metadata object. Returns an Object.
+
+#### `metadata.encryptBlobKey(metadata, passphrase, blobKey)`
+
+- `metadata` (Object) Metadata created with `metadata.create()`.
+- `passphrase` (String | Buffer)
+- `blobKey` (Buffer)
+
+Mutates `metadata` object; returns `undefined`.
+
+#### `metadata.serialize(metadata)`
+
+Serialize a metadata object. Returns a Buffer.
+
+#### `metadata.decode(buffer)`
+
+Takes a metadata buffer, decodes it, and returns an object.
+
+#### `metadata.decryptBlobKey(metadata, passphrase)`
+
+- `metadata` (Object) Metadata with an encrypted blobKey.
+- `passphrase` (String | Buffer)
+
+Returns `blobKey` as a buffer.
+
+### `blob` module
+
+```js
+import * as blob from 'secure-container/lib/blob'
+// OR
+const blob = require('secure-container/lib/blob')
+```
+
+#### `blob.encrypt(data, metadata, blobKey)`
+
+- `data` (Buffer) Data or message to encrypt.
+- `metadata` (Object) Metadata object.
+- `blobKey` (Buffer)
+
+Mutates `metadata`. Returns an object:
+
+- `blob` (Buffer) Encrypted data.
+- `blobKey` (Buffer) The `blobKey` you passed in.
+
+#### `blob.decrypt(blob, metadata, blobKey)`
+
+- `blob` (Buffer) Encrypted data.
+- `metadata` (Object) Metadata object.
+- `blobKey` (Buffer)
+
+Returns the decrypted data as a buffer.
+
+### `file` module
+
+```js
+import * as file from 'secure-container/lib/file'
+// OR
+const file = require('secure-container/lib/file')
+```
+
+#### `file.computeChecksum(metadata, blob)`
+
+- `metadata` (Buffer) Metadata as a Buffer
+- `blob` (Buffer) Encrypted blob
+
+Returns a `sha256` checksum as a buffer.
+
+#### `file.encode(fileObj)`
+
+- `fileObj` (Object)
+  - `header` (Buffer) Serialized header
+  - `checksum` (Buffer) Checksum from `file.computeChecksum()`
+  - `metadata` (Buffer) Metadata as a Buffer
+  - `blob` (Buffer) Encrypted blob
+
+Returns a buffer.
+
+#### `file.decode(fileBuffer)`
+
+The opposite of `file.encode()`. Takes a buffer and returns an object.
 
 Description
 -----------

--- a/README.md
+++ b/README.md
@@ -3,10 +3,6 @@ secure-container
 
 [![Build Status](https://travis-ci.org/ExodusMovement/secure-container.svg?branch=master)](https://travis-ci.org/ExodusMovement/secure-container)
 
-Don't use this yet.
-
-- There is no stability in this spec yet.
-- It needs a full security audit.
 
 Install
 -------


### PR DESCRIPTION
This documents the portion of the API used by `seco-file`.

It also documents the entire secure-container binary structure.

@jprichardson Suggestions for improvement welcome.