### PR TITLE
chore: add codeowners for .github dir

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,1 @@
 /.github/ @633kh4ck @mvayngrib
-/.github/*.md
-/.github/SECURITY.md @633kh4ck @mvayngrib

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+/.github/ @633kh4ck @mvayngrib
+/.github/*.md
+/.github/SECURITY.md @633kh4ck @mvayngrib


### PR DESCRIPTION
lock this down for security purposes